### PR TITLE
Document biquad filter types

### DIFF
--- a/_includes/effectchain/biquad.md
+++ b/_includes/effectchain/biquad.md
@@ -10,4 +10,4 @@ filter using biquad formula<br/><br/>
 
 <b>Q</b>: resonance<br>
 
-<b>type</b>: filter type<br>
+<b>type</b>: filter type (low-pass, high-pass, band-pass, peak, all-pass)<br>


### PR DESCRIPTION
`lp`,`hp`,`bp`, `pk`,`ap` may be confusing to some but `pk` and `ap` are hard to google even if you know that you're looking for frequency filter types.

I ended up looking into the source code: 

https://github.com/BespokeSynth/BespokeSynth/blob/9ab823c2bcdc1d672c527ca24e439228e81bd903/Source/BiquadFilterEffect.cpp#L44